### PR TITLE
feat(ghc): IDT-946 add support for liveness and readiness probes

### DIFF
--- a/charts/tomtom-base-chart/Chart.yaml
+++ b/charts/tomtom-base-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tomtom-base-chart
 description: A base Helm chart for all TomTom product units 
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: "1.0.0"

--- a/charts/tomtom-base-chart/templates/deployment.yaml
+++ b/charts/tomtom-base-chart/templates/deployment.yaml
@@ -51,6 +51,23 @@ spec:
         - secretRef:
             name: {{ include "tomtom-base-chart.fullname" $ }}-{{ .name }}-env-es
         {{- end }}
+        {{- if .Values.basicSettings.probe.liveness }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.basicSettings.probe.liveness.path }}
+            port: {{ .Values.basicSettings.port }}
+            scheme: HTTP
+          {{- with .Values.basicSettings.probe.liveness.settings }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.basicSettings.probe.readiness }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.basicSettings.probe.readiness.path }}
+            port: {{ .Values.basicSettings.port }}
+            scheme: HTTP
+        {{- end }}
         ports:
         - name: http
           containerPort: {{ .Values.basicSettings.port }}

--- a/charts/tomtom-base-chart/values.yaml
+++ b/charts/tomtom-base-chart/values.yaml
@@ -44,6 +44,24 @@ basicSettings:
   #   Port number the application listens to
   port: 80
 
+  # Probes
+  #   
+  #   liveness:  Used to determine if the application is alive or experiencing problems.
+  #              If this fails, the container will be restarted.
+  #   readiness: Used to determine if the pod is ready to receive requests.
+  #              If this fails, the pod will not receive traffic.
+  #   
+  #   "settings" can be used for custom probe options for both probes.
+  #   See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  probe: {}
+    # liveness:
+    #   path: /healthz
+    #   settings:
+    #     periodSeconds: 60
+    # readiness:
+    #   path: /ready
+    #   settings: {}
+
   # Application FQDN
   #   Hostname (FQDN) part of the URL used to access the application
   #   If no "fqdn" is set, the application will not be accessible through a domain name.


### PR DESCRIPTION
## Pull Request Description
This PR adds the capability of defining liveness and readiness probes for users of Golden Helm Chart.

### Changes Made
- Add liveness and readiness probe templates and values.

### Why?
This is requested by Watchtower (an internal application of Integration Team).

### Related Jira Issue(s)
- [IDT-946](https://jira.tomtomgroup.com/browse/IDT-946)

### Type of change
- [x] Feature

