### PR TITLE
fix(tomtom-base-chart): allow passing settings to readiness probe in the deployment

### DIFF
--- a/charts/tomtom-base-chart/templates/deployment.yaml
+++ b/charts/tomtom-base-chart/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
             path: {{ .Values.basicSettings.probe.readiness.path }}
             port: {{ .Values.basicSettings.port }}
             scheme: HTTP
+          {{ - with .Values.basicSettings.probe.readiness.settings }}
+          {{ - toYaml . | nindent 10 }}
+          {{ - end }}
         {{- end }}
         ports:
         - name: http


### PR DESCRIPTION
## Changes made
- [x] Patch `tomtom-base-chart` deployment template to allow configuration of readiness probe

No need to update the documentation (`values.yaml`) as it already mentions the possibility.