### PR TITLE
feat: DXCRA-422 update tomtom-base-chart defaults

### DIFF
--- a/charts/tomtom-base-chart/Chart.yaml
+++ b/charts/tomtom-base-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tomtom-base-chart
 description: A base Helm chart for all TomTom product units 
 type: application
-version: 0.0.10
+version: 0.0.11
 appVersion: "1.0.0"

--- a/charts/tomtom-base-chart/templates/ingress.yaml
+++ b/charts/tomtom-base-chart/templates/ingress.yaml
@@ -19,7 +19,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: letsencrypt
+    name: {{ $.Values.advancedSettings.ingress.certIssuer }}
   usages:
     - digital signature
     - key encipherment

--- a/charts/tomtom-base-chart/values.yaml
+++ b/charts/tomtom-base-chart/values.yaml
@@ -153,7 +153,7 @@ basicSettings:
   #   Enabled by default, creates a HorizontalPodAutoscaler resource
   #   This resource scales the deployment based on CPU (set to 75% by default) or memory usage.
   autoscaling:
-    enabled: true
+    enabled: false
     minReplicas: 2
     maxReplicas: 10
     targetCPUUtilizationPercentage: 75
@@ -217,14 +217,10 @@ advancedSettings:
     type: ClusterIP
 
   ingress:
-    enabled: true
-    className: "traefik"
+    enabled: false
+    className: istio
+    certIssuer: hydrantid
     annotations: {}
-      # cert-manager.io/cluster-issuer: letsencrypt
-      # kubernetes.io/ingress.allow-http: "false"
-      # traefik.ingress.kubernetes.io/router.entrypoints: websecure
-      # traefik.ingress.kubernetes.io/router.tls: "true"
-      # traefik.ingress.kubernetes.io/router.tls.options: default
     hosts: []
     # - host: www.tomtom.com
     #   paths:


### PR DESCRIPTION
Use `hydrantid` as the new default certificate issuer.

Use `istio` as the new default Ingress class.

Disable HPA and Ingress by default.