### PR TITLE
fix: NO-TICKET indentation for ingress annotations when class is Traefik

### DIFF
--- a/charts/tomtom-base-chart/templates/ingress.yaml
+++ b/charts/tomtom-base-chart/templates/ingress.yaml
@@ -46,9 +46,9 @@ metadata:
     {{- include "tomtom-base-chart.labels" . | nindent 4 }}
   {{- if or (.Values.advancedSettings.ingress.annotations) (eq .Values.advancedSettings.ingress.className "traefik") }}
   annotations:
-    {{- if eq .Values.advancedSettings.ingress.className "traefik" -}}
+    {{- if eq .Values.advancedSettings.ingress.className "traefik" }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ $fullName }}-ipallowlist@kubernetescrd
-    {{- end }}
+    {{- end -}}
     {{- with .Values.advancedSettings.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Pull Request Description

This PR fixes a YAML syntax error that occurs when ingress class name is traefik and there are additional ingress annotations passed in the values

Changes Made

- Fixes indentation in ingress.yaml

Type of change

   Bug fif

