### PR TITLE
fix: NO-TICKET indentation for ingress annotations when class is Traefik (chart version bump)

### DIFF
--- a/charts/tomtom-base-chart/Chart.yaml
+++ b/charts/tomtom-base-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tomtom-base-chart
 description: A base Helm chart for all TomTom product units 
 type: application
-version: 0.0.12
+version: 0.0.13
 appVersion: "1.0.0"


### PR DESCRIPTION
Pull Request description

This PR bumps the tomtom-base-chart version to 0.0.13 so it can be released