### PR TITLE
feat: PPIDP-503 add pdb template

### DIFF
--- a/charts/tomtom-base-chart/templates/pdb.yaml
+++ b/charts/tomtom-base-chart/templates/pdb.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.advancedSettings.pdb.enabled }}
+{{- if .Values.advancedSettings.pdb.minAvailable }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tomtom-base-chart.fullname" . }}-pdb-min
+  labels:
+    {{- include "tomtom-base-chart.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ required "minAvailable must be set and cannot be empty" .Values.advancedSettings.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "tomtom-base-chart.selectorLabels" . | nindent 6 }}
+{{- end }}
+
+
+{{- if .Values.advancedSettings.pdb.maxUnavailable }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tomtom-base-chart.fullname" . }}-pdb-max
+  labels:
+    {{- include "tomtom-base-chart.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.advancedSettings.pdb.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "tomtom-base-chart.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/tomtom-base-chart/templates/pdb.yaml
+++ b/charts/tomtom-base-chart/templates/pdb.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.advancedSettings.pdb.enabled }}
-{{- if .Values.advancedSettings.pdb.minAvailable }}
----
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -8,25 +6,13 @@ metadata:
   labels:
     {{- include "tomtom-base-chart.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ required "minAvailable must be set and cannot be empty" .Values.advancedSettings.pdb.minAvailable }}
+  {{- if .Values.advancedSettings.pdb.minAvailable }}
+  minAvailable: {{ .Values.advancedSettings.pdb.minAvailable }}
+  {{- end  }}
+  {{- if or .Values.advancedSettings.pdb.maxUnavailable ( not .Values.advancedSettings.pdb.minAvailable ) }}
+  maxUnavailable: {{ .Values.advancedSettings.pdb.maxUnavailable | default 1 }}
+  {{- end  }}
   selector:
     matchLabels:
       {{- include "tomtom-base-chart.selectorLabels" . | nindent 6 }}
-{{- end }}
-
-
-{{- if .Values.advancedSettings.pdb.maxUnavailable }}
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: {{ include "tomtom-base-chart.fullname" . }}-pdb-max
-  labels:
-    {{- include "tomtom-base-chart.labels" . | nindent 4 }}
-spec:
-  maxUnavailable: {{ .Values.advancedSettings.pdb.maxUnavailable }}
-  selector:
-    matchLabels:
-      {{- include "tomtom-base-chart.selectorLabels" . | nindent 6 }}
-{{- end }}
 {{- end }}

--- a/charts/tomtom-base-chart/values.yaml
+++ b/charts/tomtom-base-chart/values.yaml
@@ -204,12 +204,10 @@ advancedSettings:
 
   podAnnotations: {}
 
-  podSecurityContext:
-    {}
+  podSecurityContext:{}
     # fsGroup: 2000
 
-  securityContext:
-    {}
+  securityContext: {}
     # capabilities:
     #   drop:
     #   - ALL
@@ -271,6 +269,6 @@ advancedSettings:
   #   minAvailable: Minimum number of pods that must remain available during disruptions.
   #   maxUnavailable: Maximum number of pods that can be unavailable during disruptions.
   pdb:
-    enabled: false # Set to true to enable the PDB
+    enabled: true # Set to true to enable the PDB
     minAvailable: 1 # Minimum number of pods that must be available
     maxUnavailable: 2 # Maximum number of pods that can be unavailable

--- a/charts/tomtom-base-chart/values.yaml
+++ b/charts/tomtom-base-chart/values.yaml
@@ -204,8 +204,7 @@ advancedSettings:
   podSecurityContext: {}
     # fsGroup: 2000
 
-  securityContext:
-    {}
+  securityContext: {}
     # capabilities:
     #   drop:
     #   - ALL

--- a/charts/tomtom-base-chart/values.yaml
+++ b/charts/tomtom-base-chart/values.yaml
@@ -53,8 +53,7 @@ basicSettings:
   #
   #   "settings" can be used for custom probe options for both probes.
   #   See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-  probe:
-    {}
+  probe: {}
     # liveness:
     #   path: /healthz
     #   settings:
@@ -78,8 +77,7 @@ basicSettings:
   #   The average usage under regular load needs to be specified under 'requests'.
   #   The resource limits need to be specified under 'limits'.
   #   Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -92,8 +90,7 @@ basicSettings:
   #   This will create a Kubernetes ConfigMap and create envs referring to that.
   #   IMPORTANT: Use secretEnvs for sensitive environment variables. Such variables should not be
   #              a part of the Helm values and must be fetched from an external secret store like AKV.
-  envs:
-    {}
+  envs: {}
     # MY_ENV: value
 
   # Configuration files
@@ -204,10 +201,11 @@ advancedSettings:
 
   podAnnotations: {}
 
-  podSecurityContext:{}
+  podSecurityContext: {}
     # fsGroup: 2000
 
-  securityContext: {}
+  securityContext:
+    {}
     # capabilities:
     #   drop:
     #   - ALL
@@ -269,6 +267,6 @@ advancedSettings:
   #   minAvailable: Minimum number of pods that must remain available during disruptions.
   #   maxUnavailable: Maximum number of pods that can be unavailable during disruptions.
   pdb:
-    enabled: true # Set to true to enable the PDB
+    enabled: false # Set to true to enable the PDB
     minAvailable: 1 # Minimum number of pods that must be available
     maxUnavailable: 2 # Maximum number of pods that can be unavailable

--- a/charts/tomtom-base-chart/values.yaml
+++ b/charts/tomtom-base-chart/values.yaml
@@ -45,15 +45,16 @@ basicSettings:
   port: 80
 
   # Probes
-  #   
+  #
   #   liveness:  Used to determine if the application is alive or experiencing problems.
   #              If this fails, the container will be restarted.
   #   readiness: Used to determine if the pod is ready to receive requests.
   #              If this fails, the pod will not receive traffic.
-  #   
+  #
   #   "settings" can be used for custom probe options for both probes.
   #   See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-  probe: {}
+  probe:
+    {}
     # liveness:
     #   path: /healthz
     #   settings:
@@ -70,14 +71,15 @@ basicSettings:
   # Allowed IP Ranges (IP Allowlist)
   #   Range of IP addresses that are allowed to access this application through ingress
   allowedIpRanges:
-  - "0.0.0.0/0"
+    - "0.0.0.0/0"
 
   # Resource Requests & Limits
   #   CPU and memory usage requests and limits
   #   The average usage under regular load needs to be specified under 'requests'.
   #   The resource limits need to be specified under 'limits'.
   #   Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -90,7 +92,8 @@ basicSettings:
   #   This will create a Kubernetes ConfigMap and create envs referring to that.
   #   IMPORTANT: Use secretEnvs for sensitive environment variables. Such variables should not be
   #              a part of the Helm values and must be fetched from an external secret store like AKV.
-  envs: {}
+  envs:
+    {}
     # MY_ENV: value
 
   # Configuration files
@@ -122,7 +125,7 @@ basicSettings:
   #       secrets:
   #         <secret-key>: <remote-secret-name>
   #   The example below creates a secret named "my-secrets" using the pre-created secret store
-  #     "azure-kv-store" and all secrets listed under "secrets" will be accessible by the 
+  #     "azure-kv-store" and all secrets listed under "secrets" will be accessible by the
   #     application through environment variables.
   secretEnvs: []
   # - name: my-secrets
@@ -158,7 +161,6 @@ basicSettings:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 75
     # targetMemoryUtilizationPercentage: 80
-
 
 #
 # ADVANCED SETTINGS
@@ -202,10 +204,12 @@ advancedSettings:
 
   podAnnotations: {}
 
-  podSecurityContext: {}
+  podSecurityContext:
+    {}
     # fsGroup: 2000
 
-  securityContext: {}
+  securityContext:
+    {}
     # capabilities:
     #   drop:
     #   - ALL
@@ -261,3 +265,12 @@ advancedSettings:
   #   items:
   #   - key: nginx.conf
   #     path: nginx.conf
+
+  # Pod Disruption Budget (PDB)
+  #   Enables a PodDisruptionBudget resource to control voluntary disruptions to your pods.
+  #   minAvailable: Minimum number of pods that must remain available during disruptions.
+  #   maxUnavailable: Maximum number of pods that can be unavailable during disruptions.
+  pdb:
+    enabled: false # Set to true to enable the PDB
+    minAvailable: 1 # Minimum number of pods that must be available
+    maxUnavailable: 2 # Maximum number of pods that can be unavailable


### PR DESCRIPTION
## Description

This pull request introduces a new Pod Disruption Budget (PDB) template to enhance the resilience and availability of our Kubernetes deployments. The PDB helps manage voluntary disruptions, ensuring that a specified number of pods remain available during updates or maintenance activities.

## Changes Made

- Added PDB Template:
Introduced a new template to define the Pod Disruption Budget based on user-specified values.
The PDB is conditionally created based on the configuration in `values.yaml.`