### PR TITLE
feat: DXCRA-770 allow no pullSecret

### DIFF
--- a/charts/tomtom-base-chart/Chart.yaml
+++ b/charts/tomtom-base-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tomtom-base-chart
 description: A base Helm chart for all TomTom product units
 type: application
-version: 0.0.16
+version: 0.0.17
 appVersion: "1.0.0"

--- a/charts/tomtom-base-chart/templates/deployment.yaml
+++ b/charts/tomtom-base-chart/templates/deployment.yaml
@@ -26,8 +26,10 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- else }}
+      {{- if .Values.basicSettings.pullSecret }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-imagepullsecret
+      {{- end }}
       {{- end }}
       serviceAccountName: {{ include "tomtom-base-chart.serviceAccountName" . }}
       securityContext:

--- a/charts/tomtom-base-chart/templates/imagepullsecret.yaml
+++ b/charts/tomtom-base-chart/templates/imagepullsecret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.advancedSettings.imagePullSecrets }}
+{{- if and .Values.basicSettings.pullSecret (not .Values.advancedSettings.imagePullSecrets) }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/charts/tomtom-base-chart/values.yaml
+++ b/charts/tomtom-base-chart/values.yaml
@@ -23,6 +23,7 @@ basicSettings:
 
     # Image pull credentials
     #   For this section to work, the secret store needs to be created in advance.
+    #   Set to `~` (nil) to rely on kubelet identity to pull images.
     #   See docs for more information about how to create this.
     pullSecret:
       # Name of the secret store


### PR DESCRIPTION
## Description

Allow no `pullSecret` supplied when using `kubelet` identity to pull images (eg: from ACR).

## Why

Currently deployment of ACR images pulled with `kubelet` identity is not possible since all pods get forcibly assigned image pull secret.

## Changes made

- don't render Pod `spec.imagePullSecrets` if `.basicSettings.pullSecret` is `~` (ie. nil) and `.advancedSettings.imagePullSecrets` is empty.
- Bump chart version
