### PR TITLE
fix: image pull secrets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# Copyright (C) 2025 TomTom NV. All rights reserved.
-
-* @tomtom-internal/cicd-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 TomTom NV. All rights reserved.
+
+* @tomtom-internal/cicd-platform

--- a/charts/tomtom-base-chart/templates/deployment.yaml
+++ b/charts/tomtom-base-chart/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- else }}
-      {{- if .Values.basicSettings.pullSecret }}
+      {{- if .Values.basicSettings.image.pullSecret }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-imagepullsecret
       {{- end }}


### PR DESCRIPTION
## Changes Made:
Updated the Helm template to ensure the image field is explicitly defined where it was previously missing.


## Why This Change?
- Prevents possible deployment failures due to missing image references.

## Testing & Validation
- Verified the Helm chart renders correctly with the expected image field.

