### PR TITLE
feat: app - add `to-list` helper

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: app
 description: TomTom App Helm Chart
 type: application
-version: 0.1.8
+version: 0.1.9

--- a/charts/app/templates/_containers.yaml
+++ b/charts/app/templates/_containers.yaml
@@ -59,6 +59,6 @@ startupProbe: {{- toYaml .startupProbe | nindent 2 }}
 resources: {{- toYaml .resources | nindent 2 }}
 {{- end }}
 {{- if .volumeMounts }}
-volumeMounts: {{- toYaml .volumeMounts | nindent 2 }}
+volumeMounts: {{- include "common.to-list" .volumeMounts | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/app/templates/_containers.yaml
+++ b/charts/app/templates/_containers.yaml
@@ -35,7 +35,7 @@ args: {{- toYaml .args | nindent 2 }}
 lifecycle: {{- toYaml .lifecycleHooks | nindent 2 }}
 {{- end }}
 {{- if .ports }}
-ports: {{- toYaml .ports | nindent 2 }}
+ports: {{- include "common.to-list" .ports | nindent 2 }}
 {{- end }}
 {{- if .livenessProbe }}
 livenessProbe: {{- toYaml .livenessProbe | nindent 2 }}

--- a/charts/app/templates/_containers.yaml
+++ b/charts/app/templates/_containers.yaml
@@ -20,16 +20,7 @@ imagePullPolicy: {{ .imagePullPolicy }}
 securityContext: {{- toYaml .securityContext | nindent 2 }}
 {{- end }}
 {{- if .env }}
-env:
-{{- $env := .env }}
-{{- range (keys $env) | sortAlpha }}
-- name: {{ . }}
-{{- if kindIs "string" (get $env .) }}
-  value: "{{ get $env . }}"
-{{- else }}
-  {{- toYaml (get $env .) | nindent 2 }}
-{{- end }}
-{{- end }}
+env: {{- include "common.to-list" .env | nindent 2 }}
 {{- end }}
 {{- if .envFrom }}
 envFrom: {{- toYaml .envFrom | nindent 2 }}

--- a/charts/app/templates/_externalsecret.yaml
+++ b/charts/app/templates/_externalsecret.yaml
@@ -12,15 +12,5 @@ spec:
     {{- end }}
     name: {{ .target.name | default .name }}
     creationPolicy: {{ .target.creationPolicy }}
-  {{- if kindIs "slice" .data }}
-  data: {{- toYaml .data | nindent 4 }}
-  {{- else }}
-  data:
-  {{- $data := .data }}
-  {{- range (keys $data) | sortAlpha }}
-    - secretKey: {{ . }}
-      remoteRef:
-        key: {{ get $data . }}
-  {{- end }}
-  {{- end }}
+  data: {{- include "common.to-list" (dict "$values" .data "$keyAt" "secretKey" "$valueAt" "remoteRef.key") | nindent 4 }}
 {{- end -}}

--- a/charts/app/templates/_helpers.tpl
+++ b/charts/app/templates/_helpers.tpl
@@ -16,6 +16,7 @@
 {{- if kindIs "slice" (get . "$values") }}
 {{ toYaml (get . "$values") }}
 {{- else }}
+  {{- $hasKey := or (not (hasKey . "$keyAt")) (get . "$keyAt") }}
   {{- $key := get . "$keyAt" | default "name" -}}
   {{- $value := get . "$valueAt" | default "value" -}}
   {{- $values := get . "$values" | default . -}}
@@ -23,7 +24,8 @@
     {{- $v := get $values $k }}
     {{- if not $v }}{{ continue }}{{ end }}
     {{- if kindIs "string" $v }}{{ $path := regexSplit "\\." $value -1 | reverse }}{{ range $x := $path }}{{ $v = dict $x $v }}{{ end }}{{ end }}
-- {{- toYaml (mergeOverwrite (dict $key $k) $v) | nindent 2 }}
+    {{- if $hasKey }}{{ $v = mergeOverwrite (dict $key $k) $v }}{{ end }}
+- {{- toYaml $v | nindent 2 }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/app/templates/_helpers.tpl
+++ b/charts/app/templates/_helpers.tpl
@@ -13,12 +13,18 @@
 {{- if kindIs "slice" . }}
 {{ toYaml . }}
 {{- else }}
-  {{- $dict := . }}
-  {{- range $k := (keys $dict | sortAlpha) }}
-    {{- $v := get $dict $k }}
+{{- if kindIs "slice" (get . "$values") }}
+{{ toYaml (get . "$values") }}
+{{- else }}
+  {{- $key := get . "$keyAt" | default "name" -}}
+  {{- $value := get . "$valueAt" | default "value" -}}
+  {{- $values := get . "$values" | default . -}}
+  {{- range $k := keys $values | sortAlpha }}
+    {{- $v := get $values $k }}
     {{- if not $v }}{{ continue }}{{ end }}
-    {{- if kindIs "string" $v }}{{ $v = dict "value" $v }}{{ end }}
-- {{- toYaml (mergeOverwrite (dict "name" $k) $v) | nindent 2 }}
+    {{- if kindIs "string" $v }}{{ $path := regexSplit "\\." $value -1 | reverse }}{{ range $x := $path }}{{ $v = dict $x $v }}{{ end }}{{ end }}
+- {{- toYaml (mergeOverwrite (dict $key $k) $v) | nindent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/app/templates/_helpers.tpl
+++ b/charts/app/templates/_helpers.tpl
@@ -8,3 +8,17 @@
 {{- define "common.to-yaml" -}}
 {{ (omit . "name" "common" "Values" "Release" "Template") | toYaml }}
 {{- end -}}
+
+{{- define "common.to-list" -}}
+{{- if kindIs "slice" . }}
+{{ toYaml . }}
+{{- else }}
+  {{- $dict := . }}
+  {{- range $k := (keys $dict | sortAlpha) }}
+    {{- $v := get $dict $k }}
+    {{- if not $v }}{{ continue }}{{ end }}
+    {{- if kindIs "string" $v }}{{ $v = dict "value" $v }}{{ end }}
+- {{- toYaml (mergeOverwrite (dict "name" $k) $v) | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/app/templates/_pod_spec.yaml
+++ b/charts/app/templates/_pod_spec.yaml
@@ -43,6 +43,6 @@ initContainers: {{- include "common.containers" (dict "containers" .initContaine
 {{- end }}
 containers: {{- include "common.containers" (dict "containers" .containers "common" .common) | default "[]" | nindent 2 }}
 {{- if .volumes }}
-volumes: {{- toYaml .volumes | nindent 2 }}
+volumes: {{- include "common.to-list" .volumes | nindent 2 -}}
 {{- end }}
 {{- end }}

--- a/charts/app/templates/_pod_spec.yaml
+++ b/charts/app/templates/_pod_spec.yaml
@@ -43,6 +43,6 @@ initContainers: {{- include "common.containers" (dict "containers" .initContaine
 {{- end }}
 containers: {{- include "common.containers" (dict "containers" .containers "common" .common) | default "[]" | nindent 2 }}
 {{- if .volumes }}
-volumes: {{- include "common.to-list" .volumes | nindent 2 -}}
+volumes: {{- include "common.to-list" .volumes | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/app/templates/_service.yaml
+++ b/charts/app/templates/_service.yaml
@@ -26,6 +26,6 @@ spec:
   {{- if and (eq .type "LoadBalancer") .loadBalancerClass }}
   loadBalancerClass: {{ .loadBalancerClass }}
   {{- end }}
-  ports: {{- toYaml .ports | nindent 4 }}
+  ports: {{- include "common.to-list" .ports | nindent 4 }}
   selector: {{- toYaml .selector | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
Allow use of dictionaries instead of lists to make overrides possible.
Use implemented helper to simplify management of the following fields:
```
Pod#spec.containers.*.env
Pod#spec.containers.*.volumeMounts
Pod#spec.containers.*.ports
Pod#spec.volumes
ExternalSecret#spec.data
```

Provided helper supports collapsing of (some) lists to simple key-value dictionaries, which is expanded during rendering into expected K8s specs, providing easy override mechanism.

For example:
- in `Pod#spec.containers.*.env` expands:
```yaml
env:
  VAR_1: value-1
  VAR_2: value-2
```
into:
```yaml
env:
- name: VAR_1
  value: value-1
- name: VAR_2
  value: value-2
```

- in `ExternalSecret#spec.data` expands:
```yaml
data:
  VAR_1: path-in-akv-1
  VAR_2: path-in-akv-2
```
into:
```yaml
data:
- remoteRef:
    key: path-in-akv-1
  secretKey: SECRET_VAR_1
- remoteRef:
    key: path-in-akv-2
  secretKey: SECRET_VAR_2
```