### PR TITLE
feat: app - rename CRD resources

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: app
 description: TomTom App Helm Chart
 type: application
-version: 0.3.3
+version: 0.4.0

--- a/charts/app/templates/_argocdapplication.yaml
+++ b/charts/app/templates/_argocdapplication.yaml
@@ -1,4 +1,4 @@
-{{- define "common.application" -}}
+{{- define "common.argocdapplication" -}}
 {{- /* extra-logic: empty spec.syncPolicy.automated when all fields are false */}}
 {{- if and (not .spec.syncPolicy.automated.prune) (not .spec.syncPolicy.automated.selfHeal) (not .spec.syncPolicy.automated.allowEmpty) }}{{ $_ := set .spec.syncPolicy "automated" dict }}{{ end }}
 {{- /* dict-to-list: expand spec.sources dict to list of objects, discarding keys */}}

--- a/charts/app/tests/argocdapplication_test.yaml
+++ b/charts/app/tests/argocdapplication_test.yaml
@@ -1,10 +1,10 @@
-suite: test application
+suite: test argocdApplication
 templates:
   - manifests.yaml
 tests:
   - it: should work
     values:
-      - ./fixtures/application.yaml
+      - ./fixtures/argocdapplication.yaml
     asserts:
       - isKind:
           of: Application

--- a/charts/app/tests/fixtures/argocdapplication.yaml
+++ b/charts/app/tests/fixtures/argocdapplication.yaml
@@ -1,4 +1,4 @@
-applications:
+argocdApplications:
   app:
     metadata:
       namespace: ns

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
   supportedKinds:
-    applications: [argoproj.io/v1alpha1, Application, application, true]
+    argocdApplications: [argoproj.io/v1alpha1, Application, argocdApplication, true]
     authorizationPolicies: [security.istio.io/v1, AuthorizationPolicy, authorizationPolicy, false]
     certificates: [cert-manager.io/v1, Certificate, certificate, true]
     configMaps: [v1, ConfigMap, configMap, false]
@@ -129,7 +129,7 @@ common:
 
   authorizationPolicy: {}
 
-  application:
+  argocdApplication:
     spec:
       destination:
         server: https://kubernetes.default.svc

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -2,7 +2,6 @@
 global:
   supportedKinds:
     argocdApplications: [argoproj.io/v1alpha1, Application, argocdApplication, true]
-    authorizationPolicies: [security.istio.io/v1, AuthorizationPolicy, authorizationPolicy, false]
     certificates: [cert-manager.io/v1, Certificate, certificate, true]
     configMaps: [v1, ConfigMap, configMap, false]
     cronJobs: [batch/v1, CronJob, cronJob, true]
@@ -13,6 +12,7 @@ global:
     ingresses: [networking.k8s.io/v1, Ingress, ingress, false]
     istioGateways: [networking.istio.io/v1, Gateway, istioGateway, false]
     istioVirtualServices: [networking.istio.io/v1beta1, VirtualService, istioVirtualService, false]
+    istioAuthorizationPolicies: [security.istio.io/v1, AuthorizationPolicy, istioAuthorizationPolicy, false]
     networkPolicies: [networking.k8s.io/v1, NetworkPolicy, networkPolicy, false]
     persistentVolumeClaims: [v1, PersistentVolumeClaim, persistentVolumeClaim, false]
     pods: [v1, Pod, pod, true]
@@ -123,11 +123,11 @@ common:
     spec:
       ingressClassName: istio
 
-  istioVirtualService: {}
-
   istioGateway: {}
 
-  authorizationPolicy: {}
+  istioVirtualService: {}
+
+  istioAuthorizationPolicy: {}
 
   argocdApplication:
     spec:


### PR DESCRIPTION
Rename CRD resources to provide consistent values naming for 3rd-party CRDs:
- `application` to `argocdApplication`
- `authorizationPolicies` to `istioAuthorizationPolicies`